### PR TITLE
Add Protection Manager Check for Spiritual Silken

### DIFF
--- a/src/main/java/io/github/sefiraat/crystamaehistoria/slimefun/items/tools/SpiritualSilken.java
+++ b/src/main/java/io/github/sefiraat/crystamaehistoria/slimefun/items/tools/SpiritualSilken.java
@@ -78,6 +78,7 @@ public class SpiritualSilken extends RefillableUseItem {
                 final ItemSetting<Boolean> setting = settings.get(material);
                 if (!Slimefun.getProtectionManager().hasPermission(e.getPlayer(), block, Interaction.BREAK_BLOCK)) {
                     e.getPlayer().sendMessage(ChatColor.RED + "You do not have permission!");
+                    return;
                 }
                 
                 if (VALID_MATERIALS.contains(material) && setting.getValue()) {

--- a/src/main/java/io/github/sefiraat/crystamaehistoria/slimefun/items/tools/SpiritualSilken.java
+++ b/src/main/java/io/github/sefiraat/crystamaehistoria/slimefun/items/tools/SpiritualSilken.java
@@ -10,6 +10,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
@@ -70,7 +71,7 @@ public class SpiritualSilken extends RefillableUseItem {
         return e -> {
             e.cancel();
             Optional<Block> blockOptional = e.getClickedBlock();
-            if (blockOptional.isPresent()) {
+            if (blockOptional.isPresent() && Slimefun.getProtectionManager().hasPermission(e.getPlayer(), blockOptional.get(), Interaction.BREAK_BLOCK)) {
                 final Block block = blockOptional.get();
                 final Material material = block.getType();
                 final ItemSetting<Boolean> setting = settings.get(material);

--- a/src/main/java/io/github/sefiraat/crystamaehistoria/slimefun/items/tools/SpiritualSilken.java
+++ b/src/main/java/io/github/sefiraat/crystamaehistoria/slimefun/items/tools/SpiritualSilken.java
@@ -11,6 +11,7 @@ import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
@@ -71,10 +72,14 @@ public class SpiritualSilken extends RefillableUseItem {
         return e -> {
             e.cancel();
             Optional<Block> blockOptional = e.getClickedBlock();
-            if (blockOptional.isPresent() && Slimefun.getProtectionManager().hasPermission(e.getPlayer(), blockOptional.get(), Interaction.BREAK_BLOCK)) {
+            if (blockOptional.isPresent()) {
                 final Block block = blockOptional.get();
                 final Material material = block.getType();
                 final ItemSetting<Boolean> setting = settings.get(material);
+                if (!Slimefun.getProtectionManager().hasPermission(e.getPlayer(), block, Interaction.BREAK_BLOCK)) {
+                    e.getPlayer().sendMessage(ChatColor.RED + "You do not have permission!");
+                }
+                
                 if (VALID_MATERIALS.contains(material) && setting.getValue()) {
                     block.setType(Material.AIR);
                     block.getState().update(true, true);


### PR DESCRIPTION
Currently the Spiritual Silken does not care about claims when used, allowing it to be used as a tool for griefing.
This PR adds a permission check to ensure that the player has permission to break that block.